### PR TITLE
Pin axios to 1.13.6 to mitigate supply chain compromise

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@uiw/react-json-view": "^2.0.0-alpha.41",
     "@vvo/tzdb": "^6.198.0",
     "apexcharts": "5.10.4",
-    "axios": "^1.7.2",
+    "axios": "1.13.6",
     "date-fns": "4.1.0",
     "eml-parse-js": "^1.2.0-beta.0",
     "export-to-csv": "^1.3.0",


### PR DESCRIPTION
## Summary
- Pins axios from `^1.7.2` to exact version `1.13.6` to prevent yarn resolving to compromised version `1.14.1`
- Ref: https://github.com/axios/axios/issues/10636

## Context
Compromised axios versions `0.30.4` and `1.14.1` were published to npm on March 31, 2026 containing a RAT delivered via a malicious `plain-crypto-js` dependency. The semver range `^1.7.2` includes `1.14.1`, so pinning to the exact safe version prevents accidental resolution.

Note: This is a fork of KelvinTegelaar/CIPP. This pin may be overwritten on upstream sync — re-apply if needed until upstream addresses it.